### PR TITLE
set datasets version in requirements.txt

### DIFF
--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,4 +1,5 @@
 transformers==4.34.0
+datasets==2.14.0
 peft==0.4.0
 accelerate==0.23.0
 bitsandbytes==0.41.1


### PR DESCRIPTION
In the `train-deploy-llm.ipynb` notebook, when running `huggingface_estimator.fit(data, wait=True)`

if we don't enforce datasets version to 2.14.0 it leads to conflicts during the installation of the requirements.txt:

see [issue](https://github.com/philschmid/llm-sagemaker-sample/issues/13)