### PR TITLE
Name mismatch for "max_seq_length" parameter of the ScriptArguments class is corrected.

### DIFF
--- a/notebooks/train-deploy-llama3.ipynb
+++ b/notebooks/train-deploy-llama3.ipynb
@@ -214,7 +214,7 @@
     "%%writefile llama_3_70b_fsdp_qlora.yaml\n",
     "# script parameters\n",
     "model_id: \"meta-llama/Meta-Llama-3-70b\"# Hugging Face model id\n",
-    "max_seq_len:  3072 # 2048              # max sequence length for model and packing of the dataset\n",
+    "max_seq_length:  3072 # 2048              # max sequence length for model and packing of the dataset\n",
     "# sagemaker specific parameters\n",
     "train_dataset_path: \"/opt/ml/input/data/train/\" # path to where SageMaker saves train dataset\n",
     "test_dataset_path: \"/opt/ml/input/data/test/\"   # path to where SageMaker saves test dataset\n",


### PR DESCRIPTION
In the "train-deploy-llama3.ipynb" file, there was a discrepancy in the parameter name "max_seq_length" between the name specified in the YAML file and the actual parameter name in the ScriptArguments dataclass in the "run_fsdp_qlora.py" script. This issue resulted in the truncation of training examples to 512 tokens, which is the default value of "max_seq_length" in the ScriptArguments dataclass.